### PR TITLE
[BUGFIX] Add existence check for removed constant.

### DIFF
--- a/Components/Api/Resource/Article.php
+++ b/Components/Api/Resource/Article.php
@@ -101,7 +101,7 @@ class Article extends \Shopware\Components\Api\Resource\Article
      */
     protected function translateArticle(array $data, Shop $shop)
     {
-        if (version_compare(\Shopware::VERSION, '5.4.0', '<')) {
+        if (defined('\Shopware::VERSION') && version_compare(\Shopware::VERSION, '5.4.0', '<')) {
             $result = $this->translateArticleDecorator($data, $shop);
         } else {
             $result = parent::translateArticle($data, $shop);

--- a/Components/ApiUrlDecorator.php
+++ b/Components/ApiUrlDecorator.php
@@ -94,7 +94,7 @@ abstract class ApiUrlDecorator
             $router = $this->controller->Front()->Router();
 
             if ($router instanceof Router) {
-                if (\Shopware::VERSION !== '___VERSION___') {
+                if (defined('\Shopware::VERSION') && \Shopware::VERSION !== '___VERSION___') {
                     $currentVersion = \Shopware::VERSION;
                 } else {
                     // if '___VERSION___' is given, it seems to be a composer installation


### PR DESCRIPTION
The deprecated constant Shopware::VERSION has been removed and an additional check for it's
existence is needed.